### PR TITLE
Fix: Update PULL_REQUEST.md path from tmp/ to root directory

### DIFF
--- a/dot_claude/commands/create-pr.md
+++ b/dot_claude/commands/create-pr.md
@@ -3,18 +3,15 @@
 - Create a new branch
 - Commit all changes
 - Push the branch to GitHub
-- Write PR description to `./tmp/PULL_REQUEST.md`
+- Write PR description to `./PULL_REQUEST.md`
   - Check if a PR template (`PULL_REQUEST_TEMPLATE.md`) exists at the repository root or inside the `.github/` directory, and obtain its path if found.
-  - Run the following command to search for the template path:
-    ```bash
-    find . -maxdepth 2 -type f -iname "PULL_REQUEST_TEMPLATE.md"
-    ```
-  - If a template file is found, use its contents as the initial value for `./tmp/PULL_REQUEST.md`.
-- Open `./tmp/PULL_REQUEST.md` in Cursor
+  - Run Bash(find . -maxdepth 2 -type f -iname "PULL_REQUEST_TEMPLATE.md") to search for the template path:
+  - If a template file is found, use its contents as the initial value for `./PULL_REQUEST.md`.
+- Open `./PULL_REQUEST.md` in Cursor
   - I will review, modify and save the content
 - Ask me if the PR description is correct
-- Create a pull request using `./tmp/PULL_REQUEST.md` as the description
-  - `gh pr create -t <title> --body-file ./tmp/PULL_REQUEST.md --assignee @me --base <base-branch>`
+- Create a pull request using `./PULL_REQUEST.md` as the description
+  - `gh pr create -t <title> --body-file ./PULL_REQUEST.md --assignee @me --base <base-branch>`
   - Usually create against the `main` branch. If the `main` branch doesn't exist, create against the `master` branch. If $ARGUMENTS is specified, use it as the base branch
-- Execute `rm ./tmp/PULL_REQUEST.md`
+- Execute `rm ./PULL_REQUEST.md`
 - Execute `open <pull-request-url>`

--- a/dot_gitignore_global.tmpl
+++ b/dot_gitignore_global.tmpl
@@ -32,7 +32,7 @@ node_modules
 
 # Claude Code
 .claude/settings.local.json
-tmp/PULL_REQUEST.md
+PULL_REQUEST.md
 tmp/CLOSE.md
 
 # Personal


### PR DESCRIPTION
## Summary

Update PULL_REQUEST.md file path from `tmp/` directory to repository root in create-pr command and gitignore_global template.

## Changes

- Modified `dot_claude/commands/create-pr.md` to use `./PULL_REQUEST.md` instead of `./tmp/PULL_REQUEST.md`
- Updated `dot_gitignore_global.tmpl` to ignore `PULL_REQUEST.md` in root instead of `tmp/PULL_REQUEST.md`
