### PR TITLE
docs: improve create-pr command formatting and clarity

### DIFF
--- a/dot_claude/commands/create-pr.md
+++ b/dot_claude/commands/create-pr.md
@@ -5,21 +5,22 @@ description: Create a pull request to GitHub
 
 # Create a Pull Request to GitHub
 
-- Status: !`git status`
-- Diff: !`git diff`
+Status: !`git status`
+Diff: !`git diff`
 
 - Create a new branch
+  - Read @README.md to check the branch naming convention
 - Commit all changes
 - Push the branch to GitHub
 - Write PR description to `./PULL_REQUEST.md`
   - Check if a PR template (`PULL_REQUEST_TEMPLATE.md`) exists at the repository root or inside the `.github/` directory, and obtain its path if found.
-  - Run Bash(find . -maxdepth 2 -type f -iname "PULL_REQUEST_TEMPLATE.md") to search for the template path:
+  - Run Bash(`find . -maxdepth 2 -type f -iname "PULL_REQUEST_TEMPLATE.md"`) to search for the template path:
   - If a template file is found, use its contents as the initial value for `./PULL_REQUEST.md`.
-- Open `./PULL_REQUEST.md` in Cursor
+- Bash(`cursor ./PULL_REQUEST.md`)
   - I will review, modify and save the content
-- Ask me if the PR description is correct
-- Create a pull request using `./PULL_REQUEST.md` as the description
-  - `gh pr create -t <title> --body-file ./PULL_REQUEST.md --assignee @me --base <base-branch>`
-  - Usually create against the `main` branch. If the `main` branch doesn't exist, create against the `master` branch. If $ARGUMENTS is specified, use it as the base branch
-- Execute `rm ./PULL_REQUEST.md`
-- Execute `open <pull-request-url>`
+- Ask me if the PR description is correct (y/n)
+- If I say "y", Create a pull request using `./PULL_REQUEST.md` as the description
+  - Bash(`gh pr create -t <title> --body-file ./PULL_REQUEST.md --assignee @me --base <base-branch>`)
+  - !`git branch | grep -E "master|main"` to determine the base branch. If $ARGUMENTS is specified, use it as the base branch. Otherwise, use the first branch found
+- Bash(`rm ./PULL_REQUEST.md`)
+- Bash(`open <pull-request-url>`)


### PR DESCRIPTION
## Summary
create-prコマンドのドキュメントのフォーマットを改善し、より明確で読みやすくしました。

## Changes
- git statusとdiff出力セクションから不要なbullet pointsを削除
- findコマンドにバッククォートを追加して、Bashコマンドであることを明確化
- base branch決定ロジックに`git branch | grep -E "master|main"`を使用するよう修正
