### PR TITLE
refactor: move time display to right prompt in starship

### DIFF
--- a/dot_config/starship.toml
+++ b/dot_config/starship.toml
@@ -21,12 +21,16 @@ $haskell\
 $python\
 [](fg:green bg:sapphire)\
 $conda\
-[](fg:sapphire bg:lavender)\
-$time\
 [ ](fg:lavender)\
 $cmd_duration\
 $line_break\
 $character"""
+
+right_format = """
+[](lavender)\
+$time\
+[ ](lavender)\
+"""
 
 palette = 'catppuccin_mocha'
 


### PR DESCRIPTION
## Summary

Move time display from main prompt to right prompt in Starship configuration for better visual organization.

## Changes

- Removed time module from main prompt format
- Added `right_format` configuration to display time on the right side
- Maintained consistent color scheme using lavender color from Catppuccin palette
