### PR TITLE
Fix Claude notification hook jq input handling

### DIFF
--- a/dot_claude/hooks/executable_notification.sh
+++ b/dot_claude/hooks/executable_notification.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 
-# Get transcript_path from standard input
-transcript_path=$(jq -r '.transcript_path')
+input=$(cat -)
+
+# Get transcript_path from input
+transcript_path=$(echo "$input" | jq -r '.transcript_path')
 
 # Exit if the transcript file does not exist
 if [ ! -f "$transcript_path" ]; then
@@ -11,8 +13,8 @@ fi
 # Get the working directory from the transcript file
 cwd=$(grep 'parentUuid":null' "$transcript_path" | jq -r '.cwd')
 
-# Get message from standard input
-message=$(jq -r '.message')
+# Get message from input
+message=$(echo "$input" | jq -r '.message')
 
 # Display the notification with terminal-notifier
 terminal-notifier -title "Claude Code [Notification]" -subtitle "$cwd" -message "$message"


### PR DESCRIPTION
## Summary
Fix Claude notification hook to properly handle jq input parsing by capturing input to a variable first before parsing JSON fields.
