### PR TITLE
feat: add hk git hooks configuration with mise tooling

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -3,6 +3,8 @@ CLAUDE.md
 .keep
 scripts
 .vscode
+mise.toml
+hk.pkl
 {{- if not .espanso }}
 Library/Preferences/espanso
 {{- end }}

--- a/README.md
+++ b/README.md
@@ -5,3 +5,9 @@ Masato Sugiyama's dotfiles, managed with [`chezmoi`](https://github.com/twpayne/
 Install them with:
 
     chezmoi init smasato
+
+# Configure hk
+
+```bash
+hk install
+```

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,0 +1,29 @@
+amends "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Builtins.pkl"
+
+local linters = new Mapping<String, Step> {
+    ["prettier"] = Builtins.prettier
+
+    ["pkl"] {
+        glob = "*.pkl"
+        check = "pkl eval {{files}} >/dev/null"
+    }
+}
+
+hooks {
+    ["pre-commit"] {
+        fix = true
+        stash = "git"
+        steps = linters
+    }
+    ["pre-push"] {
+        steps = linters
+    }
+    ["fix"] {
+        fix = true
+        steps = linters
+    }
+    ["check"] {
+        steps = linters
+    }
+}

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,4 @@
+[tools]
+hk = "latest"
+"npm:prettier" = "latest"
+pkl = "latest"


### PR DESCRIPTION
## Summary

Add hk git hooks configuration with mise tooling support to the dotfiles repository.

## Changes

- Add hk.pkl: Configure git hooks with prettier and pkl linters for pre-commit, pre-push, and manual fix/check commands
- Add mise.toml: Set up mise tool management for hk, prettier, and pkl installations
- Update .chezmoiignore: Exclude hk.pkl and mise.toml from chezmoi management since they're development-only files
- Update README.md: Add installation instructions for hk configuration
