### PR TITLE
feat: replace nord-dircolors with vivid for dynamic color scheme support

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -8,6 +8,7 @@ packages:
       base:
         # Shell
         starship:
+        vivid:
         # Tools
         ast-grep:
         terminal-notifier:

--- a/.chezmoiexternal.toml
+++ b/.chezmoiexternal.toml
@@ -1,7 +1,3 @@
-[".dir_colors"]
-    type = "file"
-    url = "https://raw.githubusercontent.com/arcticicestudio/nord-dircolors/develop/src/dir_colors"
-    refreshPeriod = "168h"
 [".config/karabiner/assets/complex_modifications/japanese.json"]
     type = "file"
     url = "https://ke-complex-modifications.pqrs.org/json/japanese.json"

--- a/dot_zprofile.tmpl
+++ b/dot_zprofile.tmpl
@@ -7,6 +7,9 @@ export PATH="/opt/homebrew/bin:$PATH"
 export PATH="$HOME/.local/share/mise/shims:$PATH"
 export PATH="$PATH:{{ output "brew" "--prefix" | trim }}/sbin"
 
+# Color scheme
+export LS_COLORS=$(vivid generate catppuccin-mocha)
+
 # Development tools
 # Added by Toolbox App
 export PATH="$PATH:$HOME/Library/Application Support/JetBrains/Toolbox/scripts"

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -84,9 +84,6 @@ setopt magic_equal_subst
 setopt always_last_prompt
 
 autoload -U colors
-{{ if stat (joinPath .chezmoi.homeDir ".dir_colors") }}
-{{ output "dircolors" (joinPath .chezmoi.homeDir ".dir_colors") | trim }}
-{{ end }}
 
 zstyle ':completion::complete:*' use-cache true
 zstyle ':completion:*:default' menu select=1


### PR DESCRIPTION
## Summary

nord-dircolorsからvividへの移行により、動的なカラースキーム管理を実現し、外部依存を削減します。

## Changes

- `vivid`をベースパッケージに追加し、LS_COLORSの動的生成を可能に
- 静的な`nord-dircolors`ファイルの外部依存を削除
- `catppuccin-mocha`テーマを使用したvividの設定を追加
- 適切な環境設定のため、LS_COLORSのエクスポートを`.zprofile`に移動

この変更により、カラースキーム管理の柔軟性が向上し、外部依存が減少しながら、一貫したカラーテーマを維持できます。
