### PR TITLE
feat: install catppuccin theme for Claude Code

### DIFF
--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -63,15 +63,23 @@
     "type": "command",
     "command": "wt list statusline --format=claude-code"
   },
+  "enabledPlugins": {
+    "worktrunk@worktrunk": true,
+    "catppuccin@claude-themes": true
+  },
   "extraKnownMarketplaces": {
     "worktrunk": {
       "source": {
         "source": "github",
         "repo": "max-sixty/worktrunk"
       }
+    },
+    "claude-themes": {
+      "source": {
+        "source": "github",
+        "repo": "matcra587/claude-themes"
+      }
     }
   },
-  "enabledPlugins": {
-    "worktrunk@worktrunk": true
-  }
+  "theme": "custom:catppuccin:catppuccin-mocha-ansi"
 }


### PR DESCRIPTION
## Summary
- ホーム側の `~/.claude/settings.json` で有効化済みだった catppuccin テーマ設定を chezmoi ソースに反映し、`chezmoi diff` の差分を解消
- `claude-themes` マーケットプレイス（matcra587/claude-themes）を `extraKnownMarketplaces` に追加
- `catppuccin@claude-themes` プラグインを有効化し、テーマを `custom:catppuccin:catppuccin-mocha-ansi` に設定

## Test plan
- `chezmoi diff ~/.claude/settings.json` が差分なしになることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)