### PR TITLE
feat: move create-pr skill to directory layout

### DIFF
--- a/dot_claude/skills/create-pr/SKILL.md
+++ b/dot_claude/skills/create-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(find:*), Bash(gh pr create:*), Bash(rm ./PULL_REQUEST.md), Bash(open:*), Bash(hunk diff:*), Bash(herdr pane:*)
-description: Create a pull request to GitHub
+description: Create a pull request to GitHub. Use when the user asks to create a PR or open a pull request.
 ---
 
 # Create a Pull Request to GitHub


### PR DESCRIPTION
## Summary

Claude Code はスキルを `~/.claude/skills/<name>/SKILL.md` の形式で検出する。create-pr スキルは `skills/` 直下のフラットな `create-pr.md` だったため、セッションのスキル一覧に表示されなかった。ディレクトリ形式に移動して認識されるようにする。

## Changes

- `dot_claude/skills/create-pr.md` を `dot_claude/skills/create-pr/SKILL.md` に移動（内容は変更なし）
- PR 作成を依頼された際に自動で使われるよう、スキルの `description` にトリガー条件を追記

## Checklist

- [x] `chezmoi apply` で `~/.claude/skills/create-pr/SKILL.md` がデプロイされること
- [x] Claude Code のセッションで `create-pr` スキルが利用可能一覧に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
