### PR TITLE
feat: review PULL_REQUEST.md in vim in create-pr skill

### DIFF
--- a/dot_claude/skills/create-pr/SKILL.md
+++ b/dot_claude/skills/create-pr/SKILL.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(find:*), Bash(gh pr create:*), Bash(rm ./PULL_REQUEST.md), Bash(open:*), Bash(hunk diff:*), Bash(herdr pane:*)
+allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(find:*), Bash(gh pr create:*), Bash(rm ./PULL_REQUEST.md), Bash(open:*), Bash(herdr pane:*)
 description: Create a pull request to GitHub. Use when the user asks to create a PR or open a pull request.
 ---
 
@@ -18,19 +18,17 @@ Base branch: !`git branch | grep -E "master|main"` or $ARGUMENTS
   - Run Bash(`find . -maxdepth 2 -type f -iname "PULL_REQUEST_TEMPLATE.md"`) to search for `<template-path>`
   - Read(`<template-path>`) to get the template content
   - If a template file is found, use its contents as the initial value for `./PULL_REQUEST.md`
-- Show `./PULL_REQUEST.md` with hunk so I can review it
-  - `PULL_REQUEST.md` is git-ignored, so a working-tree diff cannot show it; compare it against an empty file instead
-    - Bash(`: > "${TMPDIR:-/tmp}/empty.md"`)
-    - The hunk command is: `hunk diff "${TMPDIR:-/tmp}/empty.md" ./PULL_REQUEST.md`
+- Show `./PULL_REQUEST.md` in a text editor so I can review and edit it
+  - The editor command is: `vim -c "set autoread | autocmd CursorHold,FocusGained * checktime" ./PULL_REQUEST.md`
+    - `autoread` + `checktime` make vim pick up external changes to the file, so edits you make to `./PULL_REQUEST.md` appear without a manual reload
   - If running inside Herdr (`$HERDR_ENV` is `1`), open it in a pane:
     - Bash(`herdr pane split --current --direction right --no-focus`) and read `pane_id` from the JSON response
-    - Bash(`herdr pane run <pane-id> "<the hunk command>"`)
-    - hunk does not reload file comparisons; whenever `./PULL_REQUEST.md` changes, refresh with Bash(`herdr pane send-keys <pane-id> q`) and rerun the hunk command via `herdr pane run`
-  - Otherwise, tell me to run the hunk command in my terminal
+    - Bash(`herdr pane run <pane-id> "<the editor command>"`)
+  - Otherwise, tell me to run the editor command in my terminal
 - I will review, modify and save the content
 - Ask me if the PR description is correct (y/n)
 - If I say "y", Create a pull request using `./PULL_REQUEST.md` as the description
   - Make the title from the branch's commit messages, following the semantic commit format
   - Bash(`gh pr create -t <title> --body-file ./PULL_REQUEST.md --assignee @me --base <Base branch>`)
 - Bash(`rm ./PULL_REQUEST.md`)
-- If a hunk pane was opened, Bash(`herdr pane close <pane-id>`)
+- If an editor pane was opened, Bash(`herdr pane close <pane-id>`)

--- a/dot_config/hunk/config.toml
+++ b/dot_config/hunk/config.toml
@@ -1,3 +1,4 @@
 theme = "catppuccin-mocha"
 mode = "auto"
 line_numbers = true
+watch = true


### PR DESCRIPTION
## Summary

create-pr スキルでの `PULL_REQUEST.md` レビューを、hunk ではなく vim で行うようにする。

## Changes

- `dot_claude/skills/create-pr/SKILL.md`:
  - `PULL_REQUEST.md` のレビューを hunk(空ファイルとの比較)から vim で直接開く方式に変更
  - vim は `set autoread | autocmd CursorHold,FocusGained * checktime` 付きで起動し、外部からのファイル変更を自動で取り込む
  - 手動リフレッシュ手順(`q` 送信 → hunk 再実行)を削除
- `dot_config/hunk/config.toml`: `watch = true` を追加し、watch モードをデフォルトで有効化(Git バックドのレビューで有効)

## Checklist

- [x] `chezmoi apply` で反映されることを確認
- [x] hunk の2ファイル比較で `--watch` が効かないことを再現テストで確認
