### PR TITLE
feat: install neovim with render-markdown.nvim

### DIFF
--- a/dot_claude/skills/create-pr/SKILL.md
+++ b/dot_claude/skills/create-pr/SKILL.md
@@ -19,8 +19,8 @@ Base branch: !`git branch | grep -E "master|main"` or $ARGUMENTS
   - Read(`<template-path>`) to get the template content
   - If a template file is found, use its contents as the initial value for `./PULL_REQUEST.md`
 - Show `./PULL_REQUEST.md` in a text editor so I can review and edit it
-  - The editor command is: `vim -c "set autoread | autocmd CursorHold,FocusGained * checktime" ./PULL_REQUEST.md`
-    - `autoread` + `checktime` make vim pick up external changes to the file, so edits you make to `./PULL_REQUEST.md` appear without a manual reload
+  - The editor command is: `nvim -c "set autoread | autocmd CursorHold,FocusGained * checktime" ./PULL_REQUEST.md`
+    - `autoread` + `checktime` make nvim pick up external changes to the file, so edits you make to `./PULL_REQUEST.md` appear without a manual reload
   - If running inside Herdr (`$HERDR_ENV` is `1`), open it in a pane:
     - Bash(`herdr pane split --current --direction right --no-focus`) and read `pane_id` from the JSON response
     - Bash(`herdr pane run <pane-id> "<the editor command>"`)

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -24,6 +24,7 @@ hk = "latest"
 aube = "latest"
 worktrunk = "latest"
 hunk = "latest"
+neovim = "latest"
 
 # npm packages
 claude-code = "latest"

--- a/dot_config/nvim/init.lua
+++ b/dot_config/nvim/init.lua
@@ -1,0 +1,23 @@
+-- Bootstrap lazy.nvim
+local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+if not (vim.uv or vim.loop).fs_stat(lazypath) then
+  vim.fn.system({
+    "git",
+    "clone",
+    "--filter=blob:none",
+    "--branch=stable",
+    "https://github.com/folke/lazy.nvim.git",
+    lazypath,
+  })
+end
+vim.opt.rtp:prepend(lazypath)
+
+require("lazy").setup({
+  {
+    -- Renders headings, tables, checkboxes, and code blocks inline in Markdown buffers.
+    -- Uses the markdown treesitter parsers bundled with Neovim.
+    "MeanderingProgrammer/render-markdown.nvim",
+    ft = { "markdown" },
+    opts = {},
+  },
+})


### PR DESCRIPTION
## Summary

Neovim + render-markdown.nvim を導入し、Markdown 編集を CLI でリッチに行えるようにする。create-pr スキルの `PULL_REQUEST.md` レビューも vim から nvim に切り替える。

## Changes

- `dot_config/mise/config.toml`: `neovim = "latest"` を追加(aqua:neovim/neovim、v0.12.4)
- `dot_config/nvim/init.lua`: 新規作成。lazy.nvim をブートストラップし、render-markdown.nvim を Markdown ファイルタイプで遅延ロードする最小構成
- `dot_claude/skills/create-pr/SKILL.md`: エディタコマンドを vim から nvim に変更(autoread + checktime のライブ反映はそのまま)

## Checklist

- [x] `mise install neovim` で v0.12.4 がインストールされることを確認
- [x] 初回起動時に lazy.nvim と render-markdown.nvim が自動セットアップされることを確認
- [x] Markdown バッファで render-markdown.nvim の装飾(extmark)が付与されることを確認
