### PR TITLE
feat: add catppuccin theme and mini.icons to neovim

### DIFF
--- a/dot_config/nvim/init.lua
+++ b/dot_config/nvim/init.lua
@@ -14,6 +14,24 @@ vim.opt.rtp:prepend(lazypath)
 
 require("lazy").setup({
   {
+    -- Same catppuccin-mocha palette as the hunk theme.
+    "catppuccin/nvim",
+    name = "catppuccin",
+    priority = 1000,
+    opts = {
+      flavour = "mocha",
+      transparent_background = true,
+    },
+    config = function(_, opts)
+      require("catppuccin").setup(opts)
+      vim.cmd.colorscheme("catppuccin")
+    end,
+  },
+  {
+    "nvim-mini/mini.icons",
+    opts = {},
+  },
+  {
     -- Renders headings, tables, checkboxes, and code blocks inline in Markdown buffers.
     -- Uses the markdown treesitter parsers bundled with Neovim.
     "MeanderingProgrammer/render-markdown.nvim",


### PR DESCRIPTION
## Summary

Neovim にカラーテーマとアイコンを追加する。テーマは hunk と同じ catppuccin-mocha に揃える。

## Changes

- `dot_config/nvim/init.lua`:
  - catppuccin/nvim を追加(flavour: mocha、transparent_background 有効)。起動時に `colorscheme catppuccin` を適用し、hunk のテーマ(`catppuccin-mocha`)と統一しつつターミナル背景を透過
  - mini.icons を追加。render-markdown.nvim がファイルアイコン等の描画に利用する

## Checklist

- [x] `Lazy! sync` で catppuccin と mini.icons がインストールされることを確認
- [x] 起動後の colorscheme が catppuccin-mocha になることを確認
- [x] `Normal` ハイライトに背景色が設定されず、ターミナル背景が透過されることを確認
- [x] mini.icons ロード済みの状態で render-markdown.nvim の装飾が引き続き動作することを確認
