### PR TITLE
feat: move nvim autoread config into init.lua

### DIFF
--- a/dot_claude/skills/create-pr/SKILL.md
+++ b/dot_claude/skills/create-pr/SKILL.md
@@ -19,8 +19,8 @@ Base branch: !`git branch | grep -E "master|main"` or $ARGUMENTS
   - Read(`<template-path>`) to get the template content
   - If a template file is found, use its contents as the initial value for `./PULL_REQUEST.md`
 - Show `./PULL_REQUEST.md` in a text editor so I can review and edit it
-  - The editor command is: `nvim -c "set autoread | autocmd CursorHold,FocusGained * checktime" ./PULL_REQUEST.md`
-    - `autoread` + `checktime` make nvim pick up external changes to the file, so edits you make to `./PULL_REQUEST.md` appear without a manual reload
+  - The editor command is: `nvim ./PULL_REQUEST.md`
+    - The nvim config enables `autoread` + `checktime`, so external edits to `./PULL_REQUEST.md` appear without a manual reload
   - If running inside Herdr (`$HERDR_ENV` is `1`), open it in a pane:
     - Bash(`herdr pane split --current --direction right --no-focus`) and read `pane_id` from the JSON response
     - Bash(`herdr pane run <pane-id> "<the editor command>"`)

--- a/dot_config/nvim/init.lua
+++ b/dot_config/nvim/init.lua
@@ -1,3 +1,9 @@
+-- Pick up external changes to files without a manual reload.
+vim.o.autoread = true
+vim.api.nvim_create_autocmd({ "CursorHold", "FocusGained" }, {
+  command = "checktime",
+})
+
 -- Bootstrap lazy.nvim
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
 if not (vim.uv or vim.loop).fs_stat(lazypath) then


### PR DESCRIPTION
## Summary

外部変更のライブ反映(autoread + checktime)を create-pr スキルのコマンドオプションから Neovim 設定本体に移動する。

## Changes

- `dot_config/nvim/init.lua`: `autoread` の有効化と、`CursorHold` / `FocusGained` で `checktime` を実行する autocmd を追加。create-pr に限らず、nvim で開いている全ファイルで外部変更が自動反映される
- `dot_claude/skills/create-pr/SKILL.md`: エディタコマンドを `nvim ./PULL_REQUEST.md` に簡素化(`-c` オプションを削除)

## Checklist

- [x] headless nvim で `autoread=true` と autocmd(CursorHold / FocusGained)の登録を確認
