### PR TITLE
feat: set EDITOR to nvim

### DIFF
--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -8,6 +8,7 @@ export HISTORY_IGNORE="(cd|pwd|ls|rm|mv|shutdown|exit|rmdir)"
 
 # Development environment
 export GOPATH=$HOME/dev
+export EDITOR=nvim
 
 # Compiler and build flags
 export CPPFLAGS="-Wno-enum-constexpr-conversion"


### PR DESCRIPTION
## Summary

環境変数 `EDITOR` に `nvim` を設定する。`git commit` のメッセージ編集や `chezmoi edit` などが nvim で開くようになる。

## Changes

- `dot_zshenv.tmpl`: 「Development environment」セクションに `export EDITOR=nvim` を追加
  - 非対話シェルにも適用されるよう zshenv に配置

## Checklist

- [x] `chezmoi execute-template` でテンプレートがエラーなくレンダリングされ、`export EDITOR=nvim` が出力に含まれることを確認
