### PR TITLE
feat: install herdr-file-viewer plugin

### DIFF
--- a/.chezmoiscripts/run_onchange_after_herdr-plugins.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_herdr-plugins.sh.tmpl
@@ -5,14 +5,14 @@ set -eu
 
 # Install herdr plugins used in this environment.
 # Reruns when this list changes (e.g. when a plugin is added below).
-# plugins: devashish2203/herdr-worktrunk
+# plugins: devashish2203/herdr-worktrunk smarzban/herdr-file-viewer
 
 if ! command -v herdr >/dev/null 2>&1; then
   echo "herdr not found on PATH; skipping plugin install"
   exit 0
 fi
 
-for plugin in devashish2203/herdr-worktrunk; do
+for plugin in devashish2203/herdr-worktrunk smarzban/herdr-file-viewer; do
   echo "Installing herdr plugin: ${plugin}"
   herdr plugin install "${plugin}" --yes
 done

--- a/dot_config/herdr/config.toml
+++ b/dot_config/herdr/config.toml
@@ -139,6 +139,11 @@ key = "prefix+shift+c"
 type = "plugin_action"
 command = "worktrunk.open-current"
 
+[[keys.command]]
+key = "prefix+f"
+type = "plugin_action"
+command = "herdr-file-viewer.open-file-viewer"
+
 # Legacy indexed shortcut config is still parsed for compatibility.
 # Prefer switch_tab, switch_workspace, and focus_agent for new configs.
 # [keys.indexed]

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -25,6 +25,7 @@ aube = "latest"
 worktrunk = "latest"
 hunk = "latest"
 neovim = "latest"
+glow = "latest"
 
 # npm packages
 claude-code = "latest"


### PR DESCRIPTION
## Summary

[herdr-file-viewer](https://github.com/smarzban/herdr-file-viewer) を導入する。git status 付きのディレクトリツリーと、ファイル種別に応じたコンテキスト表示(変更ファイルは diff、Markdown はレンダリング、その他はシンタックスハイライト)をスプリットペインで提供する Herdr プラグイン。

## Changes

- `.chezmoiscripts/run_onchange_after_herdr-plugins.sh.tmpl`: プラグインリストに `smarzban/herdr-file-viewer` を追加(新規マシンでも `chezmoi apply` で自動インストール)
- `dot_config/herdr/config.toml`: `prefix+f` に `herdr-file-viewer.open-file-viewer` アクションをバインド(worktrunk プラグインと同じ `plugin_action` 形式)
- `dot_config/mise/config.toml`: オプションレンダラーの `glow` を追加(Markdown レンダリング用。diff 用の delta、コード用の bat は導入済み)

## Checklist

- [x] `herdr plugin install smarzban/herdr-file-viewer --yes` でインストールされ、`herdr plugin list` に enabled で表示されることを確認
- [x] `herdr server reload-config` が diagnostics なしで適用されることを確認
- [x] `open-file-viewer` アクションの実行でビューアのペインが開くことを確認
