### PR TITLE
feat: add hk git hooks to gitconfig template

### DIFF
--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -67,3 +67,11 @@
 
 [alias]
 	fu = "!git log -n 16 --pretty=format:'%h %s' --no-merges | fzf | cut -c -7 | xargs -o git commit --fixup"
+
+[hook "hk-pre-commit"]
+	command = test \"${HK:-1}\" = \"0\" || ~/.local/share/mise/installs/hk/latest/hk run pre-commit --from-hook --staged
+	event = pre-commit
+
+[hook "hk-pre-push"]
+	command = test \"${HK:-1}\" = \"0\" || ~/.local/share/mise/installs/hk/latest/hk run pre-push --from-hook
+	event = pre-push


### PR DESCRIPTION
## Summary

`hk install` が `~/.gitconfig` に書き込む hk 管理の git hook 設定（pre-commit / pre-push）を chezmoi のテンプレートに取り込み、`chezmoi apply` で消えないようにする。

## Changes

- `dot_gitconfig.tmpl` に `[hook "hk-pre-commit"]` と `[hook "hk-pre-push"]` セクションを追加

## Checklist

- [x] `chezmoi diff ~/.gitconfig` で hk hook が削除されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
